### PR TITLE
Adpt/add response httpstatus

### DIFF
--- a/src/main/java/br/com/pipocaagil/CorraAgil/CorraAgilApplication.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/CorraAgilApplication.java
@@ -3,8 +3,10 @@ package br.com.pipocaagil.CorraAgil;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class CorraAgilApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(CorraAgilApplication.class, args);

--- a/src/main/java/br/com/pipocaagil/CorraAgil/DTO/DadosToUpdateCadastroDTO.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/DTO/DadosToUpdateCadastroDTO.java
@@ -2,13 +2,18 @@ package br.com.pipocaagil.CorraAgil.DTO;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record DadosToUpdateCadastroDTO(
         @NotNull
         Long id,
-        @NotBlank
+//        @NotNull
+//        @NotEmpty
+//        @NotBlank
         String nomecompleto,
-        @NotBlank
+//        @NotNull
+//        @NotEmpty
+//        @NotBlank
         String senha) {
 }

--- a/src/main/java/br/com/pipocaagil/CorraAgil/DTO/DadosToUpdateCadastroDTO.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/DTO/DadosToUpdateCadastroDTO.java
@@ -1,10 +1,14 @@
 package br.com.pipocaagil.CorraAgil.DTO;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record DadosToUpdateCadastroDTO(
         @NotNull
         Long id,
+        @NotBlank
         String nomecompleto,
+        @NotBlank
         String senha) {
 }

--- a/src/main/java/br/com/pipocaagil/CorraAgil/DTO/ResponseBodyStatusCadastroDTO.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/DTO/ResponseBodyStatusCadastroDTO.java
@@ -1,0 +1,13 @@
+package br.com.pipocaagil.CorraAgil.DTO;
+
+import br.com.pipocaagil.CorraAgil.model.CadastroModel;
+
+public record ResponseBodyStatusCadastroDTO(
+        Long id,
+        String nomecompleto,
+        String email) {
+
+    public ResponseBodyStatusCadastroDTO(CadastroModel cadastroModel) {
+        this(cadastroModel.getId(), cadastroModel.getNomecompleto(), cadastroModel.getEmail());
+    }
+}

--- a/src/main/java/br/com/pipocaagil/CorraAgil/controller/CadastroController.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/controller/CadastroController.java
@@ -36,6 +36,15 @@ public class CadastroController {
         return ResponseEntity.ok(pageList);
     }
 
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<?> findById(@PathVariable Long id) {
+        // Criando busca por id da variável do objeto de referência da entidade
+        CadastroModel entityById = repository.getReferenceById(id);
+
+        // Return HttpStatus 200
+        return ResponseEntity.ok(new ResponseBodyStatusCadastroDTO(entityById));
+    }
+
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional

--- a/src/main/java/br/com/pipocaagil/CorraAgil/controller/CadastroController.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/controller/CadastroController.java
@@ -5,17 +5,18 @@ import br.com.pipocaagil.CorraAgil.infra.security.TokenService;
 import br.com.pipocaagil.CorraAgil.model.CadastroModel;
 import br.com.pipocaagil.CorraAgil.repositories.CadastroRepository;
 import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -27,32 +28,54 @@ public class CadastroController {
     private final TokenService tokenService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<DadosCadastroList> findAll() {
-        return repository.findAll().stream().map(DadosCadastroList::new).toList();
+    public ResponseEntity<Page<DadosCadastroList>> findAll(@PageableDefault(size = 10) Pageable paginacao) {
+        // Adaptando Page List de todos os cadastro
+        var pageList = repository.findAll(paginacao).map(DadosCadastroList::new);
+
+        // Return HttpStatus 200 com os dados de Page List
+        return ResponseEntity.ok(pageList);
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional
-    public void createCadastro(@RequestBody @Valid DadosCadastroDTO createCadastro) {
-        repository.save(new CadastroModel(createCadastro));
-//        return ResponseEntity.status(HttpStatus.CREATED).build();
+    public ResponseEntity<?> createCadastro(@RequestBody @Valid DadosCadastroDTO createCadastro,
+                                            UriComponentsBuilder uriComponentsBuilder) {
+        // Criando variável de um novo cadastro do object reference(CadastroModel), nova entidade no DB
+        CadastroModel entityModel = repository.save(new CadastroModel(createCadastro));
+
+        // Variável URI encapsulada com Location('endereço ou Header') para FrontEnd
+        var uri = uriComponentsBuilder.path("/api/corragil/v1/{id}").buildAndExpand(entityModel.getId()).toUri();
+
+        // Response HttpStatus 201 com URI e BODY do Objeto novo criado
+        return ResponseEntity.created(uri).body(new ResponseBodyStatusCadastroDTO(entityModel));
+
     }
 
     @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional
-    public void update(@RequestBody @Valid DadosToUpdateCadastroDTO updateCadastro) {
+    public ResponseEntity<?> update(@RequestBody @Valid DadosToUpdateCadastroDTO updateCadastro) {
+        // Criando variável da entidade por busca do id deo objeto de referência
         CadastroModel entityModel = repository.getReferenceById(updateCadastro.id());
+
+        // Chamada do método passando por parâmetro a entidade para atualizar o cadastro de acordo com o id no DB
         entityModel.updateDadosPacientes(updateCadastro);
-//        return ResponseEntity.status(HttpStatus.CREATED).build();
+
+        // Return HttpStatus 200 com dados criado no record para o Header
+        return ResponseEntity.status(HttpStatus.OK).body(new ResponseBodyStatusCadastroDTO(entityModel));
     }
 
     @DeleteMapping(value = "/{id}")
-    public void delete(@PathVariable Long id) {
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        // Criando busca por id da variável do objeto de referência da entidade
         CadastroModel entityDelete = repository.findById(id).orElseThrow();
+
+        // Delete direto do DB dos dados da entidade
         repository.delete(entityDelete);
-//        return ResponseEntity.noContent().build();
+
+        // Return HttpStatus 204
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping(value = "/login",

--- a/src/main/java/br/com/pipocaagil/CorraAgil/infra/security/SecurityConfig.java
+++ b/src/main/java/br/com/pipocaagil/CorraAgil/infra/security/SecurityConfig.java
@@ -31,8 +31,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/corragil/v1/register").permitAll()
                         .requestMatchers(HttpMethod.POST,"/api/corragil/v1").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/corragil/v1").permitAll()
-                        .requestMatchers(HttpMethod.PUT,"/api/corragil/v1").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/corragil/v1/{id}").permitAll()
                         .requestMatchers(HttpMethod.DELETE,"/api/corragil/v1/{id}").permitAll()
+                        .requestMatchers(HttpMethod.PUT,"/api/corragil/v1").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,7 @@ api:
   security:
     token:
       secret: my-secret-key
+
+server:
+  error:
+    include-stacktrace: never


### PR DESCRIPTION
feat: Implementação de retorno de dados no client e server

- Adicionado retorno de dados do servidor para o client e o server.
- Incluídos novos campos no controller com anotações para facilitar o entendimento do código.
- Adicionados comentários explicativos no código.
- No endpoint de criação, agora é retornada uma URI de localização no header e o response body no POST.
- No endpoint de atualização (PUT), também foi adicionado retorno no body.